### PR TITLE
Fixing JS error when this.stop is called multiple times

### DIFF
--- a/subjects/05-imperative-to-declarative/utils/createOscillator.js
+++ b/subjects/05-imperative-to-declarative/utils/createOscillator.js
@@ -22,8 +22,10 @@ function Oscillator(audioContext) {
   }
 
   this.stop = function () {
-    if (hasConnected)
+    if (hasConnected) {
       oscillatorNode.disconnect(gainNode)
+      hasConnected = false
+    }
   }
 
   this.setType = function (type) {


### PR DESCRIPTION
I don't know if `this.stop` gets called multiple times in the theremin example, but I was getting a lot of errors when I tried to do Ryan's trickshot of composing the `<Tone />` component with the react-motion slider. This fixes the errors when `<Tone />` is re-rendered multiple times with `isPlaying` set to `false`.