### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
For those of us who <strike>are neurotic enough to</strike> care about whitespace, letting [editorconfig](http://editorconfig.org/#download) manage our editor settings definitely eases the cognitive friction when diving into React.

Looking forward to the advanced Zillow session. :)